### PR TITLE
Adding Virus_total_key argument

### DIFF
--- a/agent/subfinder_agent.py
+++ b/agent/subfinder_agent.py
@@ -46,11 +46,6 @@ def set_virustotal_api_key(
         if virustotal_key not in config["virustotal"]:
             config["virustotal"].append(virustotal_key)
     else:
-        # add to sources
-        if "sources" not in config:
-            config["sources"] = ["virustotal"]
-        elif "virustotal" not in config["sources"]:
-            config["sources"].append("virustotal")
         config["virustotal"] = [virustotal_key]
 
     try:

--- a/agent/subfinder_agent.py
+++ b/agent/subfinder_agent.py
@@ -26,7 +26,7 @@ STORAGE_NAME = "agent_subfinder_storage"
 CONFIG_PATH = "/root/.config/subfinder/provider-config.yaml"
 
 
-def _update_provider_config(
+def update_provider_config(
     virustotal_key: str,
     config_path: str = CONFIG_PATH,
 ) -> None:
@@ -38,8 +38,8 @@ def _update_provider_config(
         with open(config_path, "r") as config_file:
             config = yaml.load(config_file) or {}
     except FileNotFoundError:
-        logger.warning("Configuration file not found. Creating a new one.")
-
+        logger.error("Configuration file not found. Creating a new one.")
+        return
     # Update the 'virustotal' section
     if "virustotal" in config:
         if virustotal_key not in config["virustotal"]:
@@ -69,7 +69,7 @@ class SubfinderAgent(agent.Agent, agent_persist_mixin.AgentPersistMixin):
         virustotal_key = self.args.get("virustotal_key")
         if virustotal_key is not None:
             logger.info("Updating configuration with VirusTotal API key.")
-            _update_provider_config(virustotal_key)
+            update_provider_config(virustotal_key)
 
         agent_persist_mixin.AgentPersistMixin.__init__(self, agent_settings)
 

--- a/agent/subfinder_agent.py
+++ b/agent/subfinder_agent.py
@@ -2,7 +2,7 @@
 
 import logging
 
-import yaml
+from ruamel.yaml import YAML
 from rich import logging as rich_logging
 import tld
 from ostorlab.agent import agent
@@ -30,11 +30,14 @@ def _update_provider_config(
     config_path: str = "/root/.config/subfinder/provider-config.yaml",
 ) -> None:
     """Update the Subfinder provider configuration file with the VirusTotal API key."""
+    yaml = YAML(typ="safe")
+    yaml.default_flow_style = False  # Ensure block-style lists
+    # Load existing configuration or initialize a new one
     try:
         with open(config_path, "r") as config_file:
-            config = yaml.safe_load(config_file) or {}
+            config = yaml.load(config_file) or {}
     except FileNotFoundError:
-        config = {}
+        logger.warning("Configuration file not found. Creating a new one.")
 
     # Update the 'virustotal' section
     if "virustotal" in config:
@@ -46,7 +49,7 @@ def _update_provider_config(
     # Write back the updated configuration
     try:
         with open(config_path, "w") as config_file:
-            yaml.safe_dump(config, config_file)
+            yaml.dump(config, config_file)
         logger.info("VirusTotal API key has been added to the configuration.")
     except (IOError, OSError) as write_error:
         logger.error("Failed to write configuration file: %s", write_error)

--- a/agent/subfinder_agent.py
+++ b/agent/subfinder_agent.py
@@ -47,7 +47,9 @@ def set_virustotal_api_key(
             config["virustotal"].append(virustotal_key)
     else:
         # add to sources
-        if "sources" in config and "virustotal" not in config["sources"]:
+        if "sources" not in config:
+            config["sources"] = ["virustotal"]
+        elif "virustotal" not in config["sources"]:
             config["sources"].append("virustotal")
         config["virustotal"] = [virustotal_key]
 

--- a/agent/subfinder_agent.py
+++ b/agent/subfinder_agent.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from ruamel.yaml import YAML
+import ruamel.yaml
 from rich import logging as rich_logging
 import tld
 from ostorlab.agent import agent
@@ -31,7 +31,7 @@ def update_provider_config(
     config_path: str = CONFIG_PATH,
 ) -> None:
     """Update the Subfinder provider configuration file with the VirusTotal API key."""
-    yaml = YAML(typ="safe")
+    yaml = ruamel.yaml.YAML(typ="safe")
     yaml.default_flow_style = False  # Ensure block-style lists
     # Load existing configuration or initialize a new one
     try:

--- a/agent/subfinder_agent.py
+++ b/agent/subfinder_agent.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 STORAGE_NAME = "agent_subfinder_storage"
 
 
-def update_provider_config(
+def _update_provider_config(
     virustotal_key: str,
     config_path: str = "/root/.config/subfinder/provider-config.yaml",
 ) -> None:
@@ -65,7 +65,7 @@ class SubfinderAgent(agent.Agent, agent_persist_mixin.AgentPersistMixin):
         virustotal_key = self.args.get("virustotal_key")
         if virustotal_key is not None:
             logger.info("Updating configuration with VirusTotal API key.")
-            update_provider_config(virustotal_key)
+            _update_provider_config(virustotal_key)
 
         agent_persist_mixin.AgentPersistMixin.__init__(self, agent_settings)
 

--- a/agent/subfinder_agent.py
+++ b/agent/subfinder_agent.py
@@ -23,11 +23,12 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 STORAGE_NAME = "agent_subfinder_storage"
+CONFIG_PATH = "/root/.config/subfinder/provider-config.yaml"
 
 
 def _update_provider_config(
     virustotal_key: str,
-    config_path: str = "/root/.config/subfinder/provider-config.yaml",
+    config_path: str = CONFIG_PATH,
 ) -> None:
     """Update the Subfinder provider configuration file with the VirusTotal API key."""
     yaml = YAML(typ="safe")

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -60,6 +60,6 @@ args:
   - name: "max_subdomains"
     type: "number"
     description: "Maximum number of subdomains to return"
-  - name : "virustotal_key"
+  - name : "virustotal_api_key"
     type: "string"
     description: "Adding VirusTotal api key to get more data"

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -60,3 +60,6 @@ args:
   - name: "max_subdomains"
     type: "number"
     description: "Maximum number of subdomains to return"
+  - name : "virustotal_key"
+    type: "string"
+    description: "Adding VirusTotal api key to get more data"

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,3 +1,4 @@
 ostorlab[agent]
 rich
 tld
+PyYAML

--- a/requirement.txt
+++ b/requirement.txt
@@ -1,4 +1,4 @@
 ostorlab[agent]
 rich
 tld
-PyYAML
+ruamel.yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,3 +49,30 @@ def fixture_subfinder_agent_max_subdomains():
 
         agent = subfinder_agent.SubfinderAgent(definition, settings)
         return agent
+
+
+@pytest.fixture
+def subfinder_definition() -> agent_definitions.AgentDefinition:
+    with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
+        definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
+        definition.args = [
+            {
+                "name": "virustotal_key",
+                "value": "Justrandomvalue",
+                "type": "string",
+            },
+        ]
+        return definition
+
+
+@pytest.fixture
+def subfinder_settings() -> runtime_definitions.AgentSettings:
+    settings = runtime_definitions.AgentSettings(
+        key="agent/ostorlab/subfinder",
+        bus_url="NA",
+        bus_exchange_topic="NA",
+        args=[],
+        healthcheck_port=random.randint(5000, 6000),
+        redis_url="redis://guest:guest@localhost:6379",
+    )
+    return settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def subfinder_definition() -> agent_definitions.AgentDefinition:
         definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
         definition.args = [
             {
-                "name": "virustotal_key",
+                "name": "virustotal_api_key",
                 "value": "Justrandomvalue",
                 "type": "string",
             },

--- a/tests/provider-config-no-virustotal.yaml
+++ b/tests/provider-config-no-virustotal.yaml
@@ -1,0 +1,20 @@
+resolvers:
+    - 1.1.1.1
+    - 1.0.0.1
+    - 8.8.8.8
+    - 8.8.4.4
+    - 9.9.9.9
+
+sources:
+    - github
+    - zoomeyeapi
+    - quake
+github:
+  - ghp_lkyJGU3jv1xmwk4SDXavrLDJ4dl2pSJMzj4X
+  - ghp_gkUuhkIYdQPj13ifH4KA3cXRn8JD2lqir2d4
+zoomeyeapi:
+  - 4f73021d-ff95-4f53-937f-83d6db719eec
+quake:
+  - 0cb9030c-0a40-48a3-b8c4-fca28e466ba3
+
+subfinder-version: 2.4.5

--- a/tests/provider-config-virustotal.yaml
+++ b/tests/provider-config-virustotal.yaml
@@ -1,0 +1,24 @@
+resolvers:
+    - 1.1.1.1
+    - 1.0.0.1
+    - 8.8.8.8
+    - 8.8.4.4
+    - 9.9.9.9
+
+sources:
+    - github
+    - zoomeyeapi
+    - quake
+    - virustotal
+
+github:
+  - ghp_lkyJGU3jv1xmwk4SDXavrLDJ4dl2pSJMzj4X
+  - ghp_gkUuhkIYdQPj13ifH4KA3cXRn8JD2lqir2d4
+zoomeyeapi:
+  - 4f73021d-ff95-4f53-937f-83d6db719eec
+quake:
+  - 0cb9030c-0a40-48a3-b8c4-fca28e466ba3
+virustotal:
+  - example-api-key
+
+subfinder-version: 2.4.5

--- a/tests/subfinder_agent_test.py
+++ b/tests/subfinder_agent_test.py
@@ -149,7 +149,6 @@ def testSetVirusTotalApiKey_createsSectionAndAddsKeyWhenNoSectionExists() -> Non
         updated_config = yaml.load(fake_file.read_text()) or {}
         assert "virustotal" in updated_config
         assert updated_config["virustotal"] == ["new_key"]
-        assert "sources" in updated_config and "virustotal" in updated_config["sources"]
 
 
 def testSetVirusTotalApiKey_whenVirusTotalSectionExists_addsKeyToExistingSection() -> (
@@ -173,7 +172,6 @@ def testSetVirusTotalApiKey_whenVirusTotalSectionExists_addsKeyToExistingSection
         updated_config = yaml.load(fake_file.read_text()) or {}
         assert "virustotal" in updated_config
         assert updated_config["virustotal"] == ["example-api-key", "new_key"]
-        assert "sources" in updated_config and "virustotal" in updated_config["sources"]
 
 
 def testSetVirusTotalApiKey_whenKeyAlreadyExists_doesNotAddKeyAgain() -> None:
@@ -195,12 +193,11 @@ def testSetVirusTotalApiKey_whenKeyAlreadyExists_doesNotAddKeyAgain() -> None:
         updated_config = yaml.load(fake_file.read_text()) or {}
         assert "virustotal" in updated_config
         assert updated_config["virustotal"] == ["example-api-key"]
-        assert "sources" in updated_config and "virustotal" in updated_config["sources"]
 
 
-def testSetVirusTotalApiKey_whenFileEmpty_createSourcesAndAddVirusTotalKey() -> None:
+def testSetVirusTotalApiKey_whenFileEmpty_addVirusTotalKey() -> None:
     """
-    Test that the function creates a `sources` section and adds the `virustotal` key
+    Test that the function adds the `virustotal` key
     when the configuration file is empty.
     """
     fake_file_path = "/fake/path/provider-config-empty.yaml"
@@ -215,4 +212,3 @@ def testSetVirusTotalApiKey_whenFileEmpty_createSourcesAndAddVirusTotalKey() -> 
         updated_config = yaml.load(fake_file.read_text()) or {}
         assert "virustotal" in updated_config
         assert updated_config["virustotal"] == ["new_key"]
-        assert "sources" in updated_config and "virustotal" in updated_config["sources"]

--- a/tests/subfinder_agent_test.py
+++ b/tests/subfinder_agent_test.py
@@ -122,7 +122,7 @@ def testSetVirusTotalApiKey_whenWriteConfigurationFail_handleWriteError(
 
     sub_agent.set_virustotal_api_key(
         "existing_key",
-        str(pathlib.Path(__file__).parent / "provider-config-virustotal.yaml"),
+        str(pathlib.Path(__file__).parent / "provider-config.yaml"),
     )
 
     assert "Failed to write configuration file" in caplog.text

--- a/tests/subfinder_agent_test.py
+++ b/tests/subfinder_agent_test.py
@@ -1,6 +1,14 @@
 """Unittests for the Subfinder Agent."""
 
+import pathlib
+
+import pytest
+from pytest_mock import plugin
+
 from ostorlab.agent.message import message
+from agent import subfinder_agent as sub_agent
+from ostorlab.agent import definitions as agent_definitions
+from ostorlab.runtimes import definitions as runtime_definitions
 
 
 def testAgentSubfinder_whenFindsSubDomains_emitsBackFindings(
@@ -72,3 +80,46 @@ def testAgentSubfinder_whenMaxSubDomainsSet_emitsBackFindings(
     assert agent_mock[0].selector == "v3.asset.domain_name", (
         agent_mock[0].data["name"] == "subdomain1"
     )
+
+
+def testAgentSubfinder_whenVirustotalKeyPassed_emitsBackFindings(
+    subfinder_definition: agent_definitions.AgentDefinition,
+    subfinder_settings: runtime_definitions.AgentSettings,
+    mocker: plugin.MockerFixture,
+) -> None:
+    """
+    Test that the Subfinder agent correctly updates the provider configuration
+    with the VirusTotal key.
+    """
+    mocker_update_provider_config = mocker.patch(
+        "agent.subfinder_agent.update_provider_config"
+    )
+
+    sub_agent.SubfinderAgent(subfinder_definition, subfinder_settings)
+
+    assert mocker_update_provider_config.called is True
+    assert mocker_update_provider_config.call_args[0][0] == "Justrandomvalue"
+
+
+def testUpdateConfigurationFile_whenConfNotFound_handelFileNotFoundError(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that the provider configuration correctly handles a missing configuration file."""
+
+    sub_agent.update_provider_config("existing_key", "test_not.yaml")
+
+    assert "Configuration file not found. Creating a new one." in caplog.text
+
+
+def testupdateconfigupdate_whenWriteConfigurationFail_handelWriteErro(
+    mocker: plugin.MockerFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that the provider configuration handles a write error correctly and logs the failure."""
+    mocker.patch("ruamel.yaml.main.YAML.dump", side_effect=FileNotFoundError)
+
+    sub_agent.update_provider_config(
+        "existing_key", str(pathlib.Path(__file__).parent / "provider-config.yaml")
+    )
+
+    assert "Failed to write configuration file" in caplog.text

--- a/tests/test-requirement.txt
+++ b/tests/test-requirement.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 pytest-mock
 tld
+pyfakefs


### PR DESCRIPTION
In this PR I've added the support for virustotal api key, so subfinder can use it . we can do that by adding the key to the provider-config.yaml conf file. 

From inside the agent:
![Screenshot from 2024-12-06 11-59-22](https://github.com/user-attachments/assets/1a9d0b76-1e79-4de4-a53f-73c3b7be8063)

As you can see here, the virustotal API is called: 
![image](https://github.com/user-attachments/assets/fdc9542d-8601-4355-afeb-6b8d415c96a6)
![image](https://github.com/user-attachments/assets/769d8ba6-2aa7-418b-8ff5-5e93ab498db9)

