### PR TITLE
fix: Upgrade Go to 1.23 and pin subfinder to v2.6.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM python:3.11-slim as base
 FROM base as builder
+RUN apt-get update && apt-get install -y gcc g++ python3-dev && rm -rf /var/lib/apt/lists/*
 RUN mkdir /install
 WORKDIR /install
 COPY requirement.txt /requirement.txt
 RUN pip install --upgrade pip && pip install --prefix=/install -r /requirement.txt
 
-FROM golang:1.21-alpine AS go-build-env
-RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest
+FROM golang:1.23-alpine AS go-build-env
+RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.6.8
 
 FROM base
 RUN apt-get update && apt-get install -y bind9 dnsutils ca-certificates


### PR DESCRIPTION
## Problem
The Docker build was failing due to version incompatibilities:
1. Subfinder v2.11.0 requires Go >= 1.24.0 (which doesn't exist yet)
2. The Dockerfile was using golang:1.21-alpine
3. Missing build tools (gcc) for Python C extensions

## Changes
- Upgraded Go base image from `golang:1.21-alpine` to `golang:1.23-alpine`
- Pinned subfinder to `v2.6.8` (compatible with Go 1.23)
- Added build dependencies (gcc, g++, python3-dev) to the Python builder stage for compiling ruamel.yaml.clibz

## Error Fixed
go: github.com/projectdiscovery/subfinder/[v2@v2.11.0](vscode-file://vscode-app/snap/code/215/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) requires go >= 1.24.0 (running go 1.23.12)
error: command 'gcc' failed: No such file or directory

<img width="553" height="109" alt="image" src="https://github.com/user-attachments/assets/a946b1af-cc21-4ec8-8526-b9bc06efc789" />

