### PR TITLE
fix: Update Subfinder from v2.12.0 to v2.14.0 & bump ostorlab.yaml version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY requirement.txt /requirement.txt
 RUN pip install --upgrade pip && pip install --prefix=/install -r /requirement.txt
 
 FROM golang:1.24-alpine AS go-build-env
-RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.12.0
+RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.14.0
 
 FROM base
 RUN apt-get update && apt-get install -y bind9 dnsutils ca-certificates

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: subfinder
-version: 1.0.0
+version: 1.1.0
 image: images/logo.png 
 description: |
   This repository is an implementation of [Ostorlab Agent](https://pypi.org/project/ostorlab/) for [Subfinder](https://github.com/projectdiscovery/subfinder) discovery tool by by ProjectDiscovery.


### PR DESCRIPTION
## Summary

Updates the pinned Subfinder version from **v2.12.0** to **v2.14.0**.


Subfinder **v2.14.0** includes discovery improvements that produce significantly more results. In testing against `example.com` without provider configuration, it discovered approximately **5,000 additional subdomains** compared to **v2.12.0**.

## Changes

- Update the pinned Subfinder version from **v2.12.0** to **v2.14.0**.
- bump version in ostorlab.yaml